### PR TITLE
Docs: Fix MIGraphX link in precision support page

### DIFF
--- a/docs/reference/precision-support.rst
+++ b/docs/reference/precision-support.rst
@@ -723,7 +723,7 @@ detailed description.
         - ❌/❌
 
       *
-        - :doc:`MIGraphX <amdmigraphx:reference/cpp>`
+        - :doc:`MIGraphX <amdmigraphx:reference/MIGraphX-cpp>`
         - ✅/✅
         - ✅/✅
         - ✅/✅
@@ -863,7 +863,7 @@ detailed description.
         - ✅/✅
 
       *
-        - :doc:`MIGraphX <amdmigraphx:reference/cpp>`
+        - :doc:`MIGraphX <amdmigraphx:reference/MIGraphX-cpp>`
         - ✅/✅
         - ✅/✅
         - ✅/✅


### PR DESCRIPTION
Fix the link for MIGraphX in the precision support page