### PR TITLE
docs: redirect governance to TheRock and fix grammar

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,60 +1,20 @@
 <head>
   <meta charset="UTF-8">
-  <meta name="description" content="ROCm governance model">
-  <meta name="keywords" content="ROCm, governance">
+  <meta name="description" content="The ROCm governance model has moved to TheRock.">
+  <meta name="keywords" content="ROCm, governance, TheRock">
+  <meta name="robots" content="noindex">
+  <link rel="canonical" href="https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md">
 </head>
 
 # Governance model
 
-ROCm is a software stack made up of a collection of drivers, development tools, and APIs that enable
-GPU programming from the low-level kernel to end-user applications.
+> [!IMPORTANT]
+> **This document has moved.** The ROCm governance model and code of conduct are
+> now maintained in TheRock at
+> [ROCm/TheRock/GOVERNANCE.md](https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md).
 
-Components of ROCm that are inherited from external projects (such as
-[LLVM](https://github.com/ROCm/llvm-project) and
-[Kernel driver](https://github.com/ROCm/ROCK-Kernel-Driver)) follow their own
-governance model and code of conduct. All other components of ROCm are governed by this
-document.
+ROCm is led and managed by AMD. The ROCm governance model and code of conduct are
+maintained in TheRock, the build and release system for ROCm.
 
-## Governance
-
-ROCm is led and managed by AMD.
-
-We welcome contributions from the community. Our maintainers review all proposed changes to
-ROCm.
-
-## Roles
-
-* **Maintainers** are responsible for their designated component and repositories.
-* **Contributors** provide input and suggest changes to existing components.
-
-### Maintainers
-
-Maintainers are appointed by AMD. They are able to approve changes and can commit to our
-repositories. They must use pull requests (PRs) for all changes.
-
-You can find the list of maintainers in the CODEOWNERS file of each repository. Code owners differ
-between repositories.
-
-### Contributors
-
-If you're not a maintainer, you're a contributor. We encourage the ROCm community to contribute in
-several ways:
-
-* Help other community members by posting questions or solutions on our
-  [GitHub discussion forums](https://github.com/ROCm/ROCm/discussions)
-* Notify us of a bugs by filing an issue report on
-  [GitHub Issues](https://github.com/ROCm/ROCm/issues)
-* Improve our documentation by submitting a PR to our
-  [repository](https://github.com/ROCm/ROCm/)
-* Improve the code base (for smaller or contained changes) by submitting a PR to the component
-* Suggest larger features by adding to the *Ideas* category in the
-  [GitHub discussion forum](https://github.com/ROCm/ROCm/discussions)
-
-For more information, refer to our [contribution guidelines](CONTRIBUTING.md).
-
-## Code of conduct
-
-To engage with any AMD ROCm component that is hosted on GitHub, you must abide by the
-[GitHub community guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines)
-and the
-[GitHub community code of conduct](https://docs.github.com/en/site-policy/github-terms/github-community-code-of-conduct).
+See [ROCm Project Governance](https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md)
+for the full governance model, contributor roles, and code of conduct.

--- a/docs/about/what-is-rocm.rst
+++ b/docs/about/what-is-rocm.rst
@@ -14,7 +14,7 @@ performance and system utilities, and optimized math and compute libraries. The
 wider ROCm ecosystem includes ROCm‑enabled HPC applications and deep learning
 frameworks such as PyTorch.
 
-ROCm |ROCM_VERSION| is built through the `TheRock
+ROCm |ROCM_VERSION| is built through `TheRock
 <https://github.com/ROCm/TheRock>`__, AMD’s open build and release system.
 TheRock replaces the previous monolithic release process with a modular
 workflow that makes ROCm components easier to build, integrate, and distribute.


### PR DESCRIPTION
## Motivation

Governance for ROCm is now maintained in TheRock, the build and release system for ROCm, alongside the code of conduct. To avoid two diverging copies, this repo's `GOVERNANCE.md` should stop hosting the full model and instead redirect readers to the canonical document. This PR reduces `GOVERNANCE.md` to a short redirect stub and fixes a small grammar error in `what-is-rocm.rst` while touching nearby docs.

## Technical Details

- **`GOVERNANCE.md`** — Replaced the full governance model with a short stub:
  - A highlighted `> [!IMPORTANT]` "This document has moved" callout linking to
  [ROCm/TheRock/GOVERNANCE.md](https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md).
  - One-line statement that ROCm is led by AMD and that governance/code of conduct now live in TheRock, plus a "ROCm Project Governance" link to the canonical doc.
  - `<head>` meta updated: `description` now says the model has moved, `keywords` adds `TheRock`, plus `<meta name="robots" content="noindex">` and `<link rel="canonical" href="https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md">` so search engines drop the stub in favor of the canonical page.
- **`docs/about/what-is-rocm.rst`** — Dropped a stray article: "built through the `TheRock`" → "built through `TheRock`".

Related: the canonical governance doc is added to TheRock in a companion change (`ROCm/TheRock` branch `users/neon60/make_therock_top`).

## Test Plan

- Build the docs locally and confirm no new Sphinx warnings/errors:
  ```sh
  python -m sphinx -T -E -b html -d _build/doctrees -D language=en docs _build/html
- Verify the what-is-rocm page renders "built through TheRock" with the TheRock hyperlink intact.
- Confirm the GOVERNANCE.md moved-warning and canonical link resolve.

## Test Result

- Grammar fix verified in a prior local HTML build: the what-is-rocm page renders "is built through TheRock" (article removed, link intact).
- GOVERNANCE.md links reviewed manually and point at the canonical ROCm/TheRock/GOVERNANCE.md.
- Not verified: how the <head> meta (noindex/canonical) renders through Sphinx/MyST — raw <head> HTML in a MyST .md may be emitted into the page body rather than the document <head>, so the noindex may not take effect until confirmed in the built output. Recommend a build check before relying on it for SEO.

Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/develop/CONTRIBUTING.md#pull-requests.
