### PR TITLE
Refactor graphics OS/version selectors (#6650)

### DIFF
--- a/docs/install/include/templates/misc/os-selector-graphics-workloads.rst.jinja
+++ b/docs/install/include/templates/misc/os-selector-graphics-workloads.rst.jinja
@@ -116,16 +116,12 @@
 
    .. selector-option:: Ubuntu
       :value: ubuntu
-      :width: 4
+      :width: 6
 
    .. selector-option:: RHEL
       :value: rhel
-      :width: 4
+      :width: 6
       :toc-label: Red Hat Enterprise Linux
-
-   .. selector-option:: Windows
-      :value: windows
-      :width: 4
 
 .. selector:: Operating system
    :key: os
@@ -133,11 +129,7 @@
 
    .. selector-option:: Ubuntu
       :value: ubuntu
-      :width: 6
-
-   .. selector-option:: Windows
-      :value: windows
-      :width: 6
+      :width: 12
 
 .. selector:: Operating system
    :key: os
@@ -145,14 +137,10 @@
 
    .. selector-option:: Ubuntu
       :value: ubuntu
-      :width: 4
+      :width: 6
 
    .. selector-option:: RHEL
       :value: rhel
-      :width: 4
+      :width: 6
       :toc-label: Red Hat Enterprise Linux
-
-   .. selector-option:: Windows
-      :value: windows
-      :width: 4
 

--- a/docs/install/include/templates/os-version-selector.rst.jinja
+++ b/docs/install/include/templates/os-version-selector.rst.jinja
@@ -110,6 +110,39 @@
 {%- endmacro -%}
 
 {#--
+  all_graphics_versions(distro_name, key, header)
+  Returns a single 0-indented .. selector:: with the union of all versions
+  that have graphics: true. Used for fam=all + w=graphics.
+--#}
+{%- macro all_graphics_versions(distro_name, key, header) -%}
+{%- set ns = namespace(seen=[], vers=[]) -%}
+{%- for fam_name in data.keys() if not fam_name.startswith("_") -%}
+  {%- set family_os = os_data[fam_name] -%}
+  {%- for gpu_name in data[fam_name].keys() -%}
+    {%- if gpu_name in family_os and distro_name in family_os[gpu_name] -%}
+      {%- for v in family_os[gpu_name][distro_name]["versions"] -%}
+        {%- if v["version"] not in ns.seen and v.graphics -%}
+          {%- set _ = ns.vers.append(v["version"]) -%}
+          {%- set ns.seen = ns.seen + [v["version"]] -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor -%}
+{%- if ns.vers | length > 0 -%}
+{%- set w = col_width(ns.vers | length) %}
+.. selector:: {{ header }}
+   :key: {{ key }}
+
+{% for ver in ns.vers %}
+   .. selector-option:: {{ ver }}
+      :value: {{ ver }}
+      :width: {{ w }}
+{% endfor %}
+{%- endif -%}
+{%- endmacro -%}
+
+{#--
   all_versions(distro_name, key, header)
   Returns a single 0-indented .. selector:: with the union of all versions.
 --#}
@@ -167,7 +200,12 @@
 {{ family_all_versions("AMD Ryzen", "Ubuntu", "ubuntu-ver", "Ubuntu version") | indent(9) }}
    .. selected:: fam=all
 
-{{ all_versions("Ubuntu", "ubuntu-ver", "Ubuntu version") | indent(6) }}
+      .. selected:: w=compute
+
+{{ all_versions("Ubuntu", "ubuntu-ver", "Ubuntu version") | indent(9) }}
+      .. selected:: w=graphics
+
+{{ all_graphics_versions("Ubuntu", "ubuntu-ver", "Ubuntu version") | indent(9) }}
 
 {# ── Debian ──────────────────────────────────────────────────────────────── #}
 
@@ -197,7 +235,12 @@
 {{ family_all_versions("AMD Radeon", "Red Hat Enterprise Linux", "rhel-ver", "RHEL version") | indent(9) }}
    .. selected:: fam=all
 
-{{ all_versions("Red Hat Enterprise Linux", "rhel-ver", "RHEL version") | indent(6) }}
+      .. selected:: w=compute
+
+{{ all_versions("Red Hat Enterprise Linux", "rhel-ver", "RHEL version") | indent(9) }}
+      .. selected:: w=graphics
+
+{{ all_graphics_versions("Red Hat Enterprise Linux", "rhel-ver", "RHEL version") | indent(9) }}
 
 {# ── Oracle Linux ─────────────────────────────────────────────────────────── #}
 


### PR DESCRIPTION
* Refactor all + graphics OS/version selectors

* Revert "Refactor all + graphics OS/version selectors"

This reverts commit 02203b7b485fb7d364581eaaae1b19bb4f027789.

* remove graphics: true from &windows_11

* Reapply "Refactor all + graphics OS/version selectors"

This reverts commit 527042d51fdd6853d78f143e8f86d4bb7e1a6c4e.

* Revert "remove graphics: true from &windows_11"

This reverts commit 190e310e19be5adc4a4556804d466866c82b1dd3.

* Remove Windows for both Radeon and Ryzen + graphics

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
